### PR TITLE
Add response for cat /bin/echo

### DIFF
--- a/MTPot.py
+++ b/MTPot.py
@@ -199,7 +199,7 @@ def main():
             config.syslog_protocol)
     except MissingConfigField:
         honey_logger.info("Syslog reporting disabled, to enable it add its configuration to the configuration file")
-    COMMANDS = config.commands
+    COMMANDS = {cmd:resp.decode('string_escape') for (cmd, resp) in config.commands.items()}
 
     try:
         the_timeout = config.timeout

--- a/mirai_conf.json
+++ b/mirai_conf.json
@@ -13,7 +13,8 @@
         "rm /dev/.nippon": "",
         "echo -e \\x6b\\x61\\x6d\\x69/run > /run/.nippon": "",
         "cat /run/.nippon": "kami/run",
-        "rm /run/.nippon": ""
+        "rm /run/.nippon": "",
+        "cat /bin/echo": "\\x7fELF\\x01\\x01\\x01\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x08\\x00\\x00\\x00\\x00\\x00"
     },
     "overwrite_commands": {
         "help": "Custom response for help"


### PR DESCRIPTION
Added a working response to Mirai's cat /bin/echo command.  Adding this response causes mirai to send a link to download the mirai malware, though the honeypot will not currently perform the download.  

I had to make a change to the way commands are parsed because the honeypot needs to send actual 0x00 bytes, and not ascii strings '\x00'.